### PR TITLE
Guard active threaded sendfile task context

### DIFF
--- a/src/os/unix/ngx_linux_sendfile_chain.c
+++ b/src/os/unix/ngx_linux_sendfile_chain.c
@@ -380,6 +380,10 @@ ngx_linux_sendfile_thread(ngx_connection_t *c, ngx_buf_t *file, size_t size)
         return ctx->sent;
     }
 
+    if (task->event.active) {
+        return NGX_DONE;
+    }
+
     ctx->file = file;
     ctx->socket = c->fd;
     ctx->size = size;


### PR DESCRIPTION
Summary:
- Return NGX_DONE for an already-active threaded sendfile task before overwriting the shared connection task context.

Verification:
- git diff --check; ./auto/configure --builddir=/tmp/freenginx-issue-22-build --with-threads --with-http_v2_module --without-http_rewrite_module --without-http_gzip_module --without-pcre; make -f /tmp/freenginx-issue-22-build/Makefile -j2

Fixes #22