### PR TITLE
Clear mail proxy upstream connection after close

### DIFF
--- a/src/mail/ngx_mail_proxy_module.c
+++ b/src/mail/ngx_mail_proxy_module.c
@@ -1374,6 +1374,7 @@ ngx_mail_proxy_upstream_error(ngx_mail_session_t *s)
                        s->proxy->upstream.connection->fd);
 
         ngx_close_connection(s->proxy->upstream.connection);
+        s->proxy->upstream.connection = NULL;
     }
 
     if (s->out.len == 0) {
@@ -1395,6 +1396,7 @@ ngx_mail_proxy_internal_server_error(ngx_mail_session_t *s)
                        s->proxy->upstream.connection->fd);
 
         ngx_close_connection(s->proxy->upstream.connection);
+        s->proxy->upstream.connection = NULL;
     }
 
     ngx_mail_session_internal_server_error(s);
@@ -1410,6 +1412,7 @@ ngx_mail_proxy_close_session(ngx_mail_session_t *s)
                        s->proxy->upstream.connection->fd);
 
         ngx_close_connection(s->proxy->upstream.connection);
+        s->proxy->upstream.connection = NULL;
     }
 
     ngx_mail_close_connection(s->connection);


### PR DESCRIPTION
Summary:
- Clear the mail proxy upstream connection pointer immediately after closing it on upstream error, internal error, and session close paths.

Verification:
- git diff --check; ./auto/configure --with-mail --without-http; make -j2

Fixes #24