### PR TITLE
Fix stale gzip preallocated pointer

### DIFF
--- a/src/http/modules/ngx_http_gzip_filter_module.c
+++ b/src/http/modules/ngx_http_gzip_filter_module.c
@@ -902,6 +902,7 @@ ngx_http_gzip_filter_deflate_end(ngx_http_request_t *r,
     }
 
     ngx_pfree(r->pool, ctx->preallocated);
+    ctx->preallocated = NULL;
 
     cl = ngx_alloc_chain_link(r->pool);
     if (cl == NULL) {


### PR DESCRIPTION
Summary:
- Clear the gzip filter preallocated-memory pointer immediately after freeing it in the normal deflate-end path.

Verification:
- git diff --check; ./auto/configure --without-http_rewrite_module; make -j2; ./objs/nginx -t -p "$PWD" -c conf/nginx.conf

Fixes #25